### PR TITLE
Release 1.4.1

### DIFF
--- a/gravityview-az-filters.php
+++ b/gravityview-az-filters.php
@@ -3,7 +3,7 @@
  * Plugin Name:         GravityView - A-Z Filters Extension
  * Plugin URI:          https://www.gravitykit.com/extensions/a-z-filter/
  * Description:         Filter your entries by letters of the alphabet.
- * Version:             1.4
+ * Version:             1.4.1
  * Author:              GravityKit
  * Author URI:          https://www.gravitykit.com
  * Text Domain:         gravityview-az-filters
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 } // Exit if accessed directly
 
 /** @since 1.2 */
-define( 'GRAVITYVIEW_AZ_FILTER_VERSION', '1.4' );
+define( 'GRAVITYVIEW_AZ_FILTER_VERSION', '1.4.1' );
 
 /** @since 1.3.2 */
 define( 'GRAVITYVIEW_AZ_FILTER_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -16,6 +16,13 @@ Alphabetically filter your entries by letters of the alphabet.
 
 == Changelog ==
 
+= 1.4.1 on June 6, 2024 =
+
+This release addresses a minor issue with the A-Z Filters widget.
+
+#### 🐛 Fixed
+* Typo in a localization string used inside the A-Z Filters widget.
+
 = 1.4 on June 5, 2024 =
 
 This release adds the ability to filter entries by the "Created By" field.

--- a/widget/gravityview-a-z-entry-filter-widget.php
+++ b/widget/gravityview-a-z-entry-filter-widget.php
@@ -93,7 +93,7 @@ class Widget_A_Z_Entry_Filter extends Widget {
 	 *
 	 * Called by {@see self::get_filter_fields()} and `gravityview/common/sortable_fields` filter.
 	 *
-	 * @since TBD
+	 * @since 1.4
 	 *
 	 * @param array $fields
 	 *
@@ -357,7 +357,7 @@ class Widget_A_Z_Entry_Filter extends Widget {
 	/**
 	 * Returns user IDs by display name that starts with a given letter.
 	 *
-	 * @since TBD
+	 * @since 1.4
 	 *
 	 * @param string $letter
 	 *

--- a/widget/gravityview-a-z-entry-filter-widget.php
+++ b/widget/gravityview-a-z-entry-filter-widget.php
@@ -60,7 +60,7 @@ class Widget_A_Z_Entry_Filter extends Widget {
 			'filter_field' => [
 				'type'    => 'select',
 				'choices' => $this->get_filter_fields( $form_id ),
-				'label'   => esc_attr__( 'aaaUse this field to filter entries:', 'gravityview-az-filters' ),
+				'label'   => esc_attr__( 'Use this field to filter entries:', 'gravityview-az-filters' ),
 				'desc'    => sprintf( esc_attr__( 'Entries will be filtered based on the first character of this field. %sLearn more%s.', 'gravityview-az-filters' ), '<a href="https://docs.gravitykit.com/article/198-the-use-this-field-to-filter-entries-setting" rel="external">', '</a>' ),
 				'value'   => '',
 			],


### PR DESCRIPTION
This release addresses a minor issue with the A-Z Filters widget.

#### 🐛 Fixed
* Typo in a localization string used inside the A-Z Filters widget.


💾 [Build file](https://www.dropbox.com/scl/fi/xcdzex8vdpfeksgq2e3lg/gravityview-az-filters-1.4.1-56fc544.zip?rlkey=mpcm1k04lxvw4b3m3vw6a2f66&dl=1) (56fc544).