### PR TITLE
Fixes deprecated notices and Namings

### DIFF
--- a/gravityview-az-filters-extension.php
+++ b/gravityview-az-filters-extension.php
@@ -15,15 +15,19 @@ class A_Z_Entry_Filter_Extension extends Extension {
 
 	protected $_min_gravityview_version = '2.0-dev';
 
+	protected $_plugin_file;
+
+	protected $_plugin_version;
+
 	public function __construct() {
 
-		$this->_title         = 'A-Z Filters';
-		$this->_version       = GRAVITYVIEW_AZ_FILTER_VERSION;
-		$this->_text_domain   = 'gravityview-az-filters';
-		$this->_path          = __FILE__ ;
-		$this->_item_id       = 266;
-		$this->plugin_file    = GRAVITYVIEW_AZ_FILTER_FILE;
-		$this->plugin_version = GRAVITYVIEW_AZ_FILTER_VERSION;
+		$this->_title         	= 'A-Z Filters';
+		$this->_version       	= GRAVITYVIEW_AZ_FILTER_VERSION;
+		$this->_text_domain   	= 'gravityview-az-filters';
+		$this->_path          	= __FILE__ ;
+		$this->_item_id       	= 266;
+		$this->_plugin_file   	= GRAVITYVIEW_AZ_FILTER_FILE;
+		$this->_plugin_version 	= GRAVITYVIEW_AZ_FILTER_VERSION;
 
 		parent::__construct();
 	}

--- a/gravityview-az-filters-extension.php
+++ b/gravityview-az-filters-extension.php
@@ -12,12 +12,7 @@ if ( ! defined( 'GRAVITYVIEW_DIR' ) ) {
  * @extends \GV\Extension
  */
 class A_Z_Entry_Filter_Extension extends Extension {
-
 	protected $_min_gravityview_version = '2.0-dev';
-
-	protected $_plugin_file;
-
-	protected $_plugin_version;
 
 	public function __construct() {
 
@@ -26,14 +21,11 @@ class A_Z_Entry_Filter_Extension extends Extension {
 		$this->_text_domain   	= 'gravityview-az-filters';
 		$this->_path          	= __FILE__ ;
 		$this->_item_id       	= 266;
-		$this->_plugin_file   	= GRAVITYVIEW_AZ_FILTER_FILE;
-		$this->_plugin_version 	= GRAVITYVIEW_AZ_FILTER_VERSION;
 
 		parent::__construct();
 	}
 
 	public function add_hooks() {
-
 		// Load widget
 		add_action( 'init', array( $this, 'register_az_entry_filter_widget' ) );
 
@@ -94,7 +86,6 @@ class A_Z_Entry_Filter_Extension extends Extension {
 	 * @return void
 	 */
 	function print_styles() {
-
 		// Need to filter the CSS to load only when required.
 		wp_enqueue_style( 'gravityview_az_entry_filter', GRAVITYVIEW_AZ_FILTER_URL . '/assets/css/gravityview-az-filters.css' );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === GravityView - A-Z Filters Extension ===
 Tags: gravityview
 Requires at least: 4.3
-Tested up to: 6.0.2
+Tested up to: 6.7.1
 Stable tag: trunk
 Contributors: The GravityKit Team
 License: GPL 3 or higher
@@ -15,6 +15,11 @@ Alphabetically filter your entries by letters of the alphabet.
 3. Follow the instructions
 
 == Changelog ==
+
+= develop =
+
+#### 🐛 Fixed
+* PHP 8.2 deprecation notices.
 
 = 1.4.1 on June 6, 2024 =
 


### PR DESCRIPTION
- Implements https://github.com/GravityKit/AZ-Filters/issues/62
- The issue was that the properties plugin_file and plugin_version need to be declared as class properties before they can be used